### PR TITLE
SongInfo: Compatible with Custom Albums Mod

### DIFF
--- a/SongInfo/Patches/PnlPreparationAwakePatch.cs
+++ b/SongInfo/Patches/PnlPreparationAwakePatch.cs
@@ -39,7 +39,7 @@ public class PnlPreparationAwakePatch
         achievementsText.color = achievementsPanelHeader.color;
         achievementsText.fontStyle = achievementsPanelHeader.fontStyle;
 
-        var awardIcon = GameObject.Find("ImgStageAchievement");
+        var awardIcon = __instance.transform.Find("ImgStageAchievement").gameObject;
         awardIcon.transform.SetParent(__instance.pnlPreparationLayAchv.transform);
 
         var rectTransform = awardIcon.GetComponent<RectTransform>();

--- a/SongInfo/Patches/PnlPreparationAwakePatch.cs
+++ b/SongInfo/Patches/PnlPreparationAwakePatch.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using Il2Cpp;
+using Il2CppAssets.Scripts.Database;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -12,6 +13,15 @@ namespace Bnfour.MuseDashMods.SongInfo.Patches;
 [HarmonyPatch(typeof(PnlPreparation), nameof(PnlPreparation.Awake))]
 public class PnlPreparationAwakePatch
 {
+    private static GameObject AchievementsTextObj { get; set; }
+    private static GameObject AwardIcon { get; set; }
+
+    public static void SetAchievementsVisibility()
+    {
+        var isCustomAlbum = GlobalDataBase.s_DbMusicTag.CurMusicInfo().uid.StartsWith("999");
+        AchievementsTextObj.SetActive(!isCustomAlbum);
+        AwardIcon.SetActive(!isCustomAlbum);
+    }
     private static void Postfix(PnlPreparation __instance)
     {
         // clone the song designer string twice to display bpm and duration,
@@ -38,11 +48,12 @@ public class PnlPreparationAwakePatch
         achievementsText.fontSize = achievementsPanelHeader.fontSize;
         achievementsText.color = achievementsPanelHeader.color;
         achievementsText.fontStyle = achievementsPanelHeader.fontStyle;
+        AchievementsTextObj = achievementsText.gameObject;
 
-        var awardIcon = __instance.transform.Find("ImgStageAchievement").gameObject;
-        awardIcon.transform.SetParent(__instance.pnlPreparationLayAchv.transform);
+        AwardIcon = __instance.transform.Find("ImgStageAchievement").gameObject;
+        AwardIcon.transform.SetParent(__instance.pnlPreparationLayAchv.transform);
 
-        var rectTransform = awardIcon.GetComponent<RectTransform>();
+        var rectTransform = AwardIcon.GetComponent<RectTransform>();
         rectTransform.anchoredPosition3D = new Vector3(-109, 355, 0);
         // for some reason X coordinate assignment refuses to work (see #11),
         // so an "alternative" way to move it horizontally is used
@@ -50,5 +61,7 @@ public class PnlPreparationAwakePatch
         rectTransform.anchorMax = new Vector2(1.05f, 0.5f);
         rectTransform.anchorMin = new Vector2(1.05f, 0.5f);
         // in 1080 resolution, 1px of moving the image is 0.00125 of anchor
+        
+        SetAchievementsVisibility();
     }
 }

--- a/SongInfo/Patches/PnlPreparationAwakePatch.cs
+++ b/SongInfo/Patches/PnlPreparationAwakePatch.cs
@@ -1,6 +1,5 @@
 using HarmonyLib;
 using Il2Cpp;
-using Il2CppAssets.Scripts.Database;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/SongInfo/Patches/PnlPreparationAwakePatch.cs
+++ b/SongInfo/Patches/PnlPreparationAwakePatch.cs
@@ -13,15 +13,6 @@ namespace Bnfour.MuseDashMods.SongInfo.Patches;
 [HarmonyPatch(typeof(PnlPreparation), nameof(PnlPreparation.Awake))]
 public class PnlPreparationAwakePatch
 {
-    private static GameObject AchievementsTextObj { get; set; }
-    private static GameObject AwardIcon { get; set; }
-
-    public static void SetAchievementsVisibility()
-    {
-        var isCustomAlbum = GlobalDataBase.s_DbMusicTag.CurMusicInfo().uid.StartsWith("999");
-        AchievementsTextObj.SetActive(!isCustomAlbum);
-        AwardIcon.SetActive(!isCustomAlbum);
-    }
     private static void Postfix(PnlPreparation __instance)
     {
         // clone the song designer string twice to display bpm and duration,
@@ -48,12 +39,11 @@ public class PnlPreparationAwakePatch
         achievementsText.fontSize = achievementsPanelHeader.fontSize;
         achievementsText.color = achievementsPanelHeader.color;
         achievementsText.fontStyle = achievementsPanelHeader.fontStyle;
-        AchievementsTextObj = achievementsText.gameObject;
 
-        AwardIcon = __instance.transform.Find("ImgStageAchievement").gameObject;
-        AwardIcon.transform.SetParent(__instance.pnlPreparationLayAchv.transform);
+        var awardIcon = __instance.transform.Find("ImgStageAchievement").gameObject;
+        awardIcon.transform.SetParent(__instance.pnlPreparationLayAchv.transform);
 
-        var rectTransform = AwardIcon.GetComponent<RectTransform>();
+        var rectTransform = awardIcon.GetComponent<RectTransform>();
         rectTransform.anchoredPosition3D = new Vector3(-109, 355, 0);
         // for some reason X coordinate assignment refuses to work (see #11),
         // so an "alternative" way to move it horizontally is used
@@ -61,7 +51,5 @@ public class PnlPreparationAwakePatch
         rectTransform.anchorMax = new Vector2(1.05f, 0.5f);
         rectTransform.anchorMin = new Vector2(1.05f, 0.5f);
         // in 1080 resolution, 1px of moving the image is 0.00125 of anchor
-        
-        SetAchievementsVisibility();
     }
 }

--- a/SongInfo/Patches/PnlPreparationOnEnablePatch.cs
+++ b/SongInfo/Patches/PnlPreparationOnEnablePatch.cs
@@ -13,7 +13,7 @@ namespace Bnfour.MuseDashMods.SongInfo.Patches;
 [HarmonyPatch(typeof(PnlPreparation), nameof(PnlPreparation.OnEnable))]
 public class PnlPreparationOnEnablePatch
 {
-    private static void Postfix()
+    private static void Postfix(PnlPreparation __instance)
     {
         var info = GlobalDataBase.s_DbMusicTag.CurMusicInfo();
         var bpm = info.bpm;
@@ -27,6 +27,11 @@ public class PnlPreparationOnEnablePatch
             ?.GetComponent<LongSongNameController>();
         durationField?.Refresh($"Length: {duration}", delay: 0);
         
-        PnlPreparationAwakePatch.SetAchievementsVisibility();
+        // for Custom Albums mod compatibility:
+        // hide achievements in custom charts (uid start with 999), show in vanilla charts
+        
+        var isVanillaChart = info.uid[..3] != "999";
+        __instance.stageAchievementValue.gameObject.SetActive(isVanillaChart);
+        __instance.transform.Find("ImgStageAchievement").gameObject.SetActive(isVanillaChart);
     }
 }

--- a/SongInfo/Patches/PnlPreparationOnEnablePatch.cs
+++ b/SongInfo/Patches/PnlPreparationOnEnablePatch.cs
@@ -32,6 +32,6 @@ public class PnlPreparationOnEnablePatch
         
         var isVanillaChart = info.uid[..3] != "999";
         __instance.stageAchievementValue.gameObject.SetActive(isVanillaChart);
-        __instance.transform.Find("ImgStageAchievement").gameObject.SetActive(isVanillaChart);
+        __instance.pnlPreparationLayAchv.transform.Find("ImgStageAchievement")?.gameObject.SetActive(isVanillaChart);
     }
 }

--- a/SongInfo/Patches/PnlPreparationOnEnablePatch.cs
+++ b/SongInfo/Patches/PnlPreparationOnEnablePatch.cs
@@ -26,5 +26,7 @@ public class PnlPreparationOnEnablePatch
         var durationField = GameObject.Find(Constants.DurationStringComponentName)
             ?.GetComponent<LongSongNameController>();
         durationField?.Refresh($"Length: {duration}", delay: 0);
+        
+        PnlPreparationAwakePatch.SetAchievementsVisibility();
     }
 }


### PR DESCRIPTION
- When entering Custom Album charts, `ImgStageAchievement` cannot be found by global search as it is disabled by `CustomAlbums.dll`. Changed to absolute path search to fix this. 

- By the way, `CustomAlbums.dll` permanently disables `ImgStageAchievement`. Added visibility control code to show the icon in non-Custom Album charts and hide `stageAchievementValue` in Custom Album charts.

**Tested on `Melon Loader 0.6.1` and `Melon Loader 0.7.0`**